### PR TITLE
Pylint, flake8 in tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 venv
 *.pyc
 *.egg-info
-*.eggs
-*.tox
-*.cache
+.eggs
+.tox
+.cache
+.pytest_cache
 __pycache__

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 flake8==3.5.0
+numpy==1.14.0
+pillow==5.0.0
 pylint==1.8.2
+selenium==3.9.0
 tox==2.9.1
 tqdm==4.19.5
-selenium==3.9.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,12 @@
 [tox]
-envlist = py36
+envlist = py36,style
 
 [testenv]
 deps = pytest
 commands = {envpython} setup.py test
+         
+[testenv:style]
+deps = -rrequirements.txt
+whitelist_externals= bash
+commands = bash -c \'find . -iname "*.py" -not -regex "\(./venv/.*\)\|\(./.tox/.*\)\|\(./.eggs/.*\)" | xargs flake8\'   
+           bash -c \'find . -iname "*.py" -not -regex "\(./venv/.*\)\|\(./.tox/.*\)\|\(./.eggs/.*\)" | xargs pylint\'


### PR DESCRIPTION
Now AFAIK Travis CI will check every PR if the code is in conformity with PEP-8.

Command 
```
find . -iname "*.py" -not -regex "\(./venv/.*\)\|\(./.tox/.*\)\|\(./.eggs/.*\)" | xargs flake8
```
finds every python file and gives it to flake8/pylint.